### PR TITLE
Add `.rescue_duplicate_key_errors` to document

### DIFF
--- a/lib/minidoc/indexes.rb
+++ b/lib/minidoc/indexes.rb
@@ -4,10 +4,28 @@ module Minidoc::Indexes
   extend ActiveSupport::Concern
 
   module ClassMethods
+    MONGO_DUPLICATE_KEY_ERROR_CODE = 11000
+
     def ensure_index(key_or_keys, options = {})
       indexes = Array(key_or_keys).map { |key| { key => 1 } }.reduce(:merge)
 
       collection.ensure_index(indexes, options)
+    end
+
+    # Rescue a <tt>Mongo::OperationFailure</tt> exception which originated from
+    # duplicate key error (error code 11000) in the given block.
+    #
+    # Returns the status of the operation in the given block, or +false+ if the
+    # exception was raised.
+    def rescue_duplicate_key_errors
+      yield
+    rescue Mongo::OperationFailure => exception
+      if exception.respond_to?(:error_code) &&
+        exception.error_code == MONGO_DUPLICATE_KEY_ERROR_CODE
+        return false
+      else
+        raise
+      end
     end
   end
 end

--- a/test/indexes_test.rb
+++ b/test/indexes_test.rb
@@ -29,6 +29,15 @@ class IndexesTest < Minidoc::TestCase
     assert index_info(Company, "name_1")["unique"]
   end
 
+  def test_rescue_duplicate_key_errors_not_raising_exception
+    Company.ensure_index(:name, unique: true)
+
+    Company.rescue_duplicate_key_errors do
+      Company.create!(name: "CodeClimate")
+      Company.create!(name: "CodeClimate")
+    end
+  end
+
   private
 
   def index_info(klass, name)


### PR DESCRIPTION
This helper method will rescue a duplicate key error that raises in a given block. Useful when you are dealing with race condition from the client and it is safe to ignore the duplication.