### PR TITLE
Allow for not dropping indexes when clearing

### DIFF
--- a/lib/minidoc/test_helpers.rb
+++ b/lib/minidoc/test_helpers.rb
@@ -3,11 +3,22 @@ class Minidoc
     extend self
 
     def clear_database
-      Minidoc.database.collections.each do |coll|
-        next if coll.name.include?("system")
-        coll.remove({})
-        coll.drop_indexes
-      end
+      clear_collections
+      clear_indexes
+    end
+
+    def clear_collections
+      each_collection { |c| c.remove({}) }
+    end
+
+    def clear_indexes
+      each_collection(&:drop_indexes)
+    end
+
+    def each_collection(&block)
+      Minidoc.database.collections.
+        reject { |c| c.name.include?("system") }.
+        each(&block)
     end
   end
 end


### PR DESCRIPTION
Indexes may be added through Minidoc::Indexes.ensure_index which runs at the
time the model class is interpreted. Minidoc::TestHelpers.clear_database is
intended to be fired in setup/teardown (or before/after), which would be
*after* the code is loaded and ensure_index has run.

This ordering clears out indexes we intend to be there. If we then have specs
that rely on the indexes being present (maybe we want to test the behavior of
violating an index, or just ensure data-sanity in the specs), these specs break
in non-obvious ways.

/cc @codeclimate/review @brynary