### PR TITLE
Create an increment_x method, not next_x

### DIFF
--- a/lib/minidoc/counters.rb
+++ b/lib/minidoc/counters.rb
@@ -12,9 +12,9 @@ class Minidoc
         attribute field, Integer, default: start
 
         class_eval(<<-EOM)
-          def next_#{field}
+          def increment_#{field}
             Minidoc::Counters::Incrementor.
-              new(self, :#{field}).next_value(#{step_size})
+              new(self, :#{field}).increment(#{step_size})
           end
         EOM
       end
@@ -26,7 +26,7 @@ class Minidoc
         @field = field
       end
 
-      def next_value(step_size = 1)
+      def increment(step_size = 1)
         result = record.class.collection.find_and_modify(
           query: { _id: record.id },
           update: { "$inc" => { field => step_size } },

--- a/test/counters_test.rb
+++ b/test/counters_test.rb
@@ -17,9 +17,9 @@ class CountersTest < Minidoc::TestCase
     x = SimpleCounter.create!
 
     assert_equal 0, x.counter
-    assert_equal 1, x.next_counter
-    assert_equal 2, x.next_counter
-    assert_equal 3, x.next_counter
+    assert_equal 1, x.increment_counter
+    assert_equal 2, x.increment_counter
+    assert_equal 3, x.increment_counter
     assert_equal 3, x.reload.counter
   end
 
@@ -27,9 +27,9 @@ class CountersTest < Minidoc::TestCase
     x = AdvancedCounter.create!
 
     assert_equal 2, x.counter
-    assert_equal 5, x.next_counter
-    assert_equal 8, x.next_counter
-    assert_equal 11, x.next_counter
+    assert_equal 5, x.increment_counter
+    assert_equal 8, x.increment_counter
+    assert_equal 11, x.increment_counter
     assert_equal 11, x.reload.counter
   end
 
@@ -38,9 +38,9 @@ class CountersTest < Minidoc::TestCase
     counters = []
 
     [
-      Thread.new { 5.times { counters << x.next_counter } },
-      Thread.new { 5.times { counters << x.next_counter } },
-      Thread.new { 5.times { counters << x.next_counter } },
+      Thread.new { 5.times { counters << x.increment_counter } },
+      Thread.new { 5.times { counters << x.increment_counter } },
+      Thread.new { 5.times { counters << x.increment_counter } },
     ].map(&:join)
 
     assert_equal 15, counters.uniq.length


### PR DESCRIPTION
This creates better naming at the attribute level:

Old (attribute itself makes little sense):

    counter :build_number

    x.build_number
    # => 0

    x.next_build_number
    # => 1

New (incrementing method and attribute make sense on their own):

    counter :builds_count

    x.builds_count
    # => 0

    x.increment_builds_count
    # => 1

/cc @wfleming