### PR TITLE
Add Minidoc#atomic_set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.0.0
   - 2.1.1
 services: mongodb
+before_install:
+  - gem update bundler

--- a/lib/minidoc.rb
+++ b/lib/minidoc.rb
@@ -66,6 +66,11 @@ class Minidoc
     collection.update({ "_id" => id }, updates)
   end
 
+  def self.atomic_set(query, attributes)
+    result = collection.update(query, "$set" => attributes)
+    result["ok"] == 1 && result["n"] == 1
+  end
+
   def self.value_class
     @value_class ||= Class.new(self) do
       attribute_set.each do |attr|
@@ -172,6 +177,18 @@ class Minidoc
 
   def update(updates)
     self.class.update_one(id, updates)
+  end
+
+  def atomic_set(query, attributes)
+    query[:_id] = id
+
+    if self.class.atomic_set(query, attributes)
+      attributes.each do |name, value|
+        self[name] = value
+      end
+
+      true
+    end
   end
 
   def as_value

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ I18n.load_path << File.expand_path("../locale/en.yml", __FILE__)
 
 class User < Minidoc
   attribute :name, String
+  attribute :age, Integer
 end
 
 $mongo = Mongo::MongoClient.from_uri(ENV["MONGODB_URI"] || "mongodb://localhost")

--- a/test/persistence_test.rb
+++ b/test/persistence_test.rb
@@ -151,4 +151,33 @@ class PersistenceTest < Minidoc::TestCase
     assert_equal nil, user.name
     assert_equal nil, user.reload.name
   end
+
+  def test_atomic_set_failure
+    user = User.create(name: "from", age: 18)
+
+    refute user.atomic_set({ name: "not-from" }, name: "to")
+    assert_equal "from", user.name
+    assert_equal 18, user.age
+
+    user.reload
+    assert_equal "from", user.name
+    assert_equal 18, user.age
+  end
+
+  def test_atomic_set_success
+    user = User.create(name: "from", age: 18)
+    other_user = User.create(name: "from", age: 21)
+
+    assert user.atomic_set({ name: "from" }, name: "to")
+    assert_equal "to", user.name
+    assert_equal 18, user.age
+
+    user.reload
+    assert_equal "to", user.name
+    assert_equal 18, user.age
+
+    other_user.reload
+    assert_equal "from", other_user.name
+    assert_equal 21, other_user.age
+  end
 end


### PR DESCRIPTION
`Minidoc#atomic_set(query, attributes)` attempts an update of the record
matching `query` (along with the instance's `_id`) and returns `true` or
`false` indicating if the update was successful.

The update is said to be atomic because there is no race condition: if two
processes attempt the same update (provided that update changes a field used in
the query), the database guarantees only one will succeed and return success to
its caller.

Example:

```ruby
if record.atomic_update({ evaluated_at: nil }, evaluated_at: Time.now)
  # proceed with exactly-once evaluation logic
else
  # abort, someone else is performing or has performed that logic
end
```